### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## How to use ?
 
-    var easySoap    = require('easySoap');
+    var easySoap    = require('easysoap');
 
     //soap client params
     var clientParams = {


### PR DESCRIPTION
I added `"easysoap": "0.5.0"` in my package.json file
And I ran `npm install`
Then I tried to run the server but got

```
Warning: Cannot find module 'easySoap' Use --force to continue.

Aborted due to warnings.
    Warning:  Use --force to continue.

        Aborted due to warnings.
```

The problem was fixed by typing the module name in all lower case in the require.
