### PR TITLE
Param of array check fix

### DIFF
--- a/src/request/request.js
+++ b/src/request/request.js
@@ -84,7 +84,7 @@
             }
 
             // array value given, then create item for every value
-            if (_.isArray(value) && !_.isObject(value)) {
+            if (_.isArray(value)) {
                 return _.map(value,
                     (valueItem) => getParamAsString(valueItem, name, paramData, attributes)
                 ).join('');


### PR DESCRIPTION
That condition `_.isArray && !_.isObject` always ignore array params because
underscore function isObject returns true for an array. 

When we have a param like this:

```js
{
  param: [
    {foo: "bar1"},
    {foo: "bar2"}
  ]
}
```

we are expect see output like this

```xml
<param>
  <foo>bar1</foo>
</param>
<param>
  <foo>bar2</foo>
</param>
```

but we see

```xml
<param>
  <0>
    <foo>bar1</foo>
  </0>
  <1>
    <foo>bar2</foo>
  </1>
</param>
```