### PR TITLE
special case for arrays

### DIFF
--- a/src/request/request.js
+++ b/src/request/request.js
@@ -96,7 +96,7 @@
                 var valueAsString = _.map(value,
                     (valueItem, valueKey) => {
 
-                        if (_.isObject(valueItem)) {
+                        if (!_.isArray(valueItem) && _.isObject(valueItem)) {
                             var valueItem = _.map(valueItem, (valueItemItem, valueKeyKey) => {
                                 return getParamAsString(valueItemItem, valueKeyKey, paramData[name], attributes);
                             }).join('');


### PR DESCRIPTION
`_.isObject` returns true for Arrays; add a check to avoid collapsing `tag: ["a", "b", "c"]` into `<0>a</0><1>b</1><2>c</2>` but rather `<tag>a</tag><tag>b</tag><tag>c</tag>`